### PR TITLE
Fixed the bug in doincludes to make jemdoc compatible with python3 if include or includeraw is used.

### DIFF
--- a/jemdoc
+++ b/jemdoc
@@ -469,7 +469,7 @@ def doincludes(f, l):
   i = 'include{'
   if l.startswith(ir):
     nf = io.open(l[len(ir):-2], 'rb')
-    f.outf.write(nf.read())
+    f.outf.write(nf.read().decode('utf-8'))
     nf.close()
   elif l.startswith(i):
     f.pushfile(l[len(i):-2])


### PR DESCRIPTION
".decode('utf-8')" should be added to line 472 to make jemdoc compatible with python3 if there are some instances of include / includeraw.