### PR TITLE
Fix the bug in doincludes so that the right trailing whitespaces/newlines will be ignored from the included files names

### DIFF
--- a/jemdoc
+++ b/jemdoc
@@ -467,12 +467,13 @@ def pc(f, ditchcomments=True):
 def doincludes(f, l):
   ir = 'includeraw{'
   i = 'include{'
+  l = l.rstrip()
   if l.startswith(ir):
-    nf = io.open(l[len(ir):-2], 'rb')
+    nf = io.open(l[len(ir):-1], 'rb')
     f.outf.write(nf.read())
     nf.close()
   elif l.startswith(i):
-    f.pushfile(l[len(i):-2])
+    f.pushfile(l[len(i):-1])
   else:
     return False
 


### PR DESCRIPTION
if a jemdoc file, say, publications.jemdoc, ends with "#includeraw{patent.html}" with no newline at the end, the jemdoc will error out saying that the file "patent.htm" does not exist. To fix this issue, the  trailing whitespaces/newliens is removed from the variable "l" in line 470. Furthermore, the indexes in lines 472 and 276 are changed accordingly.