### PR TITLE
Fix bug in the "np" function.

### DIFF
--- a/jemdoc
+++ b/jemdoc
@@ -549,9 +549,9 @@ def np(f, withcount=False, eatblanks=True):
 
   # in both cases, ditch the trailing \n.
   if withcount:
-    return (s[:-1], c)
+    return (s, c)
   else:
-    return s[:-1]
+    return s
 
 def quote(s):
   return re.sub(r"""[\\*/+"'<>&$%\.~[\]-]""", r'\\\g<0>', s)


### PR DESCRIPTION
Slicing the variable "s" when returning causes the link not to appear properly since such slicing remove the closing square bracket. This issue would not raise if there is a blank line after the link. So to avoid adding a blank line after a link specifically at the end of a file such slicing on the variable "s" is removed.

The attached zipped file contains a jemdoc file using which this issue can be reproduced. 
[ReproduceBug_PR#3.zip](https://github.com/wsshin/jemdoc_mathjax/files/5038077/ReproduceBug_PR.3.zip)

The following images also compare the before/after resolving the issue.
![Before](https://user-images.githubusercontent.com/5162994/89584185-a56e5c80-d809-11ea-87cd-9555830c88df.png)
![After](https://user-images.githubusercontent.com/5162994/89584199-ac956a80-d809-11ea-8d80-2525227cc878.png)


