### PR TITLE
update mathjax from v2.7.5 to v2.7.9

### DIFF
--- a/example/mysite.conf
+++ b/example/mysite.conf
@@ -1,6 +1,6 @@
 [bodystart]
 <!-- MathJax -->
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML' async>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/latest.js?config=TeX-MML-AM_CHTML' async>
 </script>
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({


### PR DESCRIPTION
There have been several bug fixes to mathjax v2.7 since the release of v2.7.5, which jemdoc+MathJax is currently loading. This commit applies the latest mathjax v2.7.9 (not v3.x, which includes super many breaking changes).

https://github.com/mathjax/MathJax/releases