### PR TITLE
jemdoc: fix string syntax warnings

### DIFF
--- a/jemdoc
+++ b/jemdoc
@@ -714,9 +714,9 @@ def br(b, f, tableblock=False):
   for m in r.findall(b):
     repl = os.environ.get(m)
     if repl == None:
-      b = re.sub("!\$%s\$!" % m, 'FAILED_MATCH_' + m, b)
+      b = re.sub(r"!\$%s\$!" % m, 'FAILED_MATCH_' + m, b)
     else:
-      b = re.sub("!\$%s\$!" % m, repl, b)
+      b = re.sub(r"!\$%s\$!" % m, repl, b)
 
   # Deal with literal backspaces.
   if f.eqs and f.eqsupport:
@@ -892,7 +892,7 @@ def gethl(lang):
     d['special'] = ['cols', 'optvar', 'param', 'problem', 'norm2', 'norm1',
             'value', 'minimize', 'maximize', 'rows', 'rand',
             'randn', 'printval', 'matrix']
-    d['error'] = ['\w*Error',]
+    d['error'] = [r'\w*Error',]
     d['commentuntilend'] = '#'
     d['strings'] = True
   elif lang in ['c', 'c++', 'cpp']:
@@ -901,7 +901,7 @@ def gethl(lang):
             'clock_t', 'struct', 'long', 'extern', 'char']
     d['operator'] = ['#include.*', '#define', '@pyval{', '}@', '@pyif{',
              '@py{']
-    d['error'] = ['\w*Error',]
+    d['error'] = [r'\w*Error',]
     d['commentuntilend'] = ['//', '/*', ' * ', '*/']
   elif lang in ('rb', 'ruby'):
     d['statement'] = putbsbs(['while', 'until', 'unless', 'if', 'elsif',
@@ -910,7 +910,7 @@ def gethl(lang):
     d['operator'] = putbsbs(['and', 'not', 'or'])
     d['builtin'] = putbsbs(['true', 'false', 'require', 'warn'])
     d['special'] = putbsbs(['IO'])
-    d['error'] = putbsbs(['\w*Error',])
+    d['error'] = putbsbs([r'\w*Error',])
     d['commentuntilend'] = '#'
     d['strings'] = True
     d['strings'] = True
@@ -928,13 +928,13 @@ def gethl(lang):
     d['builtin'] = putbsbs(['gem', 'gcc', 'python', 'curl', 'wget', 'ssh',
                 'latex', 'find', 'sed', 'gs', 'grep', 'tee',
                 'gzip', 'killall', 'echo', 'touch',
-                'ifconfig', 'git', '(?<!\.)tar(?!\.)'])
+                'ifconfig', 'git', r'(?<!\.)tar(?!\.)'])
     d['commentuntilend'] = '#'
     d['strings'] = True
   elif lang == 'matlab':
     d['statement'] = putbsbs(['max', 'min', 'find', 'rand', 'cumsum', 'randn', 'help',
                      'error', 'if', 'end', 'for'])
-    d['operator'] = ['&gt;', 'ans =', '>>', '~', '\.\.\.']
+    d['operator'] = ['&gt;', 'ans =', '>>', '~', r'\.\.\.']
     d['builtin'] = putbsbs(['csolve'])
     d['commentuntilend'] = '%'
     d['strings'] = True
@@ -1026,14 +1026,14 @@ def geneq(f, eq, dpi, wl, outname):
   basefile = texfile[:-4]
   g = os.fdopen(fd, 'wb')
 
-  preamble = '\documentclass{article}\n'
+  preamble = '\\documentclass{article}\n'
   for p in f.eqpackages:
     preamble += '\\usepackage{%s}\n' % p
   for p in f.texlines:
     # Replace \{ and \} in p with { and }.
     # XXX hack.
     preamble += re.sub(r'\\(?=[{}])', '', p + '\n')
-  preamble += '\pagestyle{empty}\n\\begin{document}\n'
+  preamble += '\\pagestyle{empty}\n\\begin{document}\n'
   g.write(preamble)
   
   # Write the equation itself.
@@ -1043,7 +1043,7 @@ def geneq(f, eq, dpi, wl, outname):
     g.write('$%s$' % eq)
 
   # Finish off the tex file.
-  g.write('\n\\newpage\n\end{document}')
+  g.write('\n\\newpage\n\\end{document}')
   g.close()
 
   exts = ['.tex', '.aux', '.dvi', '.log']
@@ -1193,7 +1193,7 @@ def codeblock(f, g):
         out(f.outf, l)
       elif g[1] == 'jemdoc':
         # doing this more nicely needs python 2.5.
-        for x in ('#', '~', '>>>', '\~', '{'):
+        for x in ('#', '~', '>>>', r'\~', '{'):
           if str(l).lstrip().startswith(x):
             out(f.outf, '</tt><pre class="tthl">')
             out(f.outf, l + '</pre><tt class="tthl">')
@@ -1418,13 +1418,13 @@ def procfile(f):
       # Quickly pull out the equation here:
       # Check we don't already have the terminating character in a whole-line
       # equation without linebreaks, eg \( Ax=b \):
-      if not s.strip().endswith('\)'):
+      if not s.strip().endswith(r'\)'):
         while True:
           l = nl(f, codemode=True)
           if not l:
             break
           s += l
-          if l.strip() == '\)':
+          if l.strip() == r'\)':
             break
       r = br(s.strip(), f)
       r = mathjaxeqresub(r)


### PR DESCRIPTION
Clean up the Python strings to avoid warnings like:

`/usr/bin/jemdoc:717: SyntaxWarning: invalid escape sequence '\$'
  b = re.sub("!\$%s\$!" % m, 'FAILED_MATCH_' + m, b)
/usr/bin/jemdoc:719: SyntaxWarning: invalid escape sequence '\$'
  b = re.sub("!\$%s\$!" % m, repl, b)
/usr/bin/jemdoc:895: SyntaxWarning: invalid escape sequence '\w'
  d['error'] = ['\w*Error',]
/usr/bin/jemdoc:904: SyntaxWarning: invalid escape sequence '\w'
  d['error'] = ['\w*Error',]
/usr/bin/jemdoc:913: SyntaxWarning: invalid escape sequence '\w'
  d['error'] = putbsbs(['\w*Error',])
/usr/bin/jemdoc:931: SyntaxWarning: invalid escape sequence '\.'
  'ifconfig', 'git', '(?<!\.)tar(?!\.)'])
/usr/bin/jemdoc:937: SyntaxWarning: invalid escape sequence '\.'
  d['operator'] = ['&gt;', 'ans =', '>>', '~', '\.\.\.']
/usr/bin/jemdoc:1029: SyntaxWarning: invalid escape sequence '\d'
  preamble = '\documentclass{article}\n'
/usr/bin/jemdoc:1036: SyntaxWarning: invalid escape sequence '\p'
  preamble += '\pagestyle{empty}\n\\begin{document}\n'
/usr/bin/jemdoc:1046: SyntaxWarning: invalid escape sequence '\e'
  g.write('\n\\newpage\n\end{document}')
/usr/bin/jemdoc:1196: SyntaxWarning: invalid escape sequence '\~'
  for x in ('#', '~', '>>>', '\~', '{'):
/usr/bin/jemdoc:1421: SyntaxWarning: invalid escape sequence '\)'
  if not s.strip().endswith('\)'):
/usr/bin/jemdoc:1427: SyntaxWarning: invalid escape sequence '\)'
  if l.strip() == '\)':
`